### PR TITLE
fix: use absolute imports everywhere

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,13 @@ cd `dirname $0`
 
 sudo pip install -r requirements.txt
 
+if echo $* | grep -q -- --constants
+then
+    sudo env PYTHONPATH=$PWD python teabot/constants_setup.py
+    echo "Please copy these values into teabot.contants.Constants then re-run."
+    exit 0
+fi
+
 if [ -f teabot.service ]
 then
     echo "Please delete teabot.service file before continuing."

--- a/run
+++ b/run
@@ -2,6 +2,8 @@
 
 cd `dirname $0`
 
+export PYTHONPATH=$PWD:$PYTHONPATH
+
 if echo $* | grep -q -- --fake
 then
     ( \
@@ -13,4 +15,4 @@ then
     exit 0
 fi
 
-exec sudo python -u teabot/worker.py
+exec sudo env PYTHONPATH=$PYTHONPATH python -u teabot/worker.py

--- a/teabot/constants_setup.py
+++ b/teabot/constants_setup.py
@@ -1,5 +1,5 @@
 from __future__ import division
-from inputs.weight import Weight
+from teabot.inputs.weight import Weight
 
 
 weight_sensor = Weight()
@@ -10,6 +10,7 @@ stored_data_dict = dict()
 
 def store_reading(key):
     stored_data_dict[key] = weight_sensor.read_sensor()
+
 
 print (raw_input('Place empty teapot on scale and press enter.'))
 

--- a/teabot/dash_listener.py
+++ b/teabot/dash_listener.py
@@ -1,7 +1,7 @@
 from scapy.all import sniff, ARP
 from expiringdict import ExpiringDict
 
-from server_communicator import ServerCommunicator
+from teabot.server_communicator import ServerCommunicator
 
 server_link = ServerCommunicator()
 

--- a/teabot/inputs/fake.py
+++ b/teabot/inputs/fake.py
@@ -1,6 +1,6 @@
 import json
 
-from inputs.base import BaseSensor
+from teapot.inputs.base import BaseSensor
 
 
 class FakeSensor(BaseSensor):

--- a/teabot/server_communicator.py
+++ b/teabot/server_communicator.py
@@ -1,5 +1,5 @@
 import requests
-from constants import TeapotStatuses, Constants
+from teabot.constants import TeapotStatuses, Constants
 from datetime import datetime, timedelta
 import json
 

--- a/teabot/status_helpers.py
+++ b/teabot/status_helpers.py
@@ -1,8 +1,8 @@
 from __future__ import division
 from collections import namedtuple
 from datetime import datetime
-from constants import Constants
-from teapot_state import get_teapot_state_machine
+from teabot.constants import Constants
+from teabot.teapot_state import get_teapot_state_machine
 
 
 class TeapotStatus(object):

--- a/teabot/teapot_state.py
+++ b/teabot/teapot_state.py
@@ -1,5 +1,5 @@
 from fysom import Fysom
-from constants import TeapotStatuses, Transistions
+from teabot.constants import TeapotStatuses, Transistions
 
 # Cached teapot_state_machine, retrive it using get_teapot_state_machine
 teapot_state_machine = None

--- a/teabot/worker.py
+++ b/teabot/worker.py
@@ -1,17 +1,17 @@
 import sys
-from status_helpers import TeapotStatus
-from server_communicator import ServerCommunicator
-from constants import TeapotStatuses
+from teabot.status_helpers import TeapotStatus
+from teabot.server_communicator import ServerCommunicator
+from teabot.constants import TeapotStatuses
 import rollbar
 
 
 if '--fake' in sys.argv:
-    from inputs.fake import FakeSensor
+    from teabot.inputs.fake import FakeSensor
     weight_sensor = FakeSensor(key='weight', pipe=sys.stdin)
     temperature_sensor = FakeSensor(key='temperature', pipe=sys.stdin)
 else:
-    from inputs.weight import Weight
-    from inputs.temperature import Temperature
+    from teabot.inputs.weight import Weight
+    from teabot.inputs.temperature import Temperature
     weight_sensor = Weight()
     temperature_sensor = Temperature()
 


### PR DESCRIPTION
relative imports in the root of the teabot package work fine, but when I
added teabot.inputs.base and tried to make weight.py and temperature.py
import from that, everything got a bit confusing.

tox automatically adds the project root to PYHONPATH, so my absolute
imports passed the test suite, but everything exploded when I tried
to run it on the pi because it doesn't have PYTHONPATH set correctly.

There are two ways to solve this problem: either make the wrapper
scripts set PYTHONPATH, or fiddle with sys.path at the top of
worker.py and constants_setup.py before doing any local imports.
Since we already have a ./run shell script, I decided that modifying
this was the cleanest solution.

Note that sudo often strips out environment variables for security
reasons, so you have to inject them using env after you've gained
root previlages.